### PR TITLE
README example err fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ client, err := vkapi.NewVKClient(vkapi.DeviceIPhone, "username", "password")
 ## Authorizing using access token
 
 ```go
-client, err := vkapi.NewVKClientWithToken("token")
+client, err := vkapi.NewVKClientWithToken("token", nil)
 ```
 
 ## Listening longpoll events


### PR DESCRIPTION
func NewVKClientWithToken(token string, options *TokenOptions) (*VKClient, error) gets 2 parameters, but only one is given in an example. To avoid the exceptions the options variable might be declared as nil.

func NewVKClientWithToken(token string, options *TokenOptions) (*VKClient, error) принимает 2 значения,  тогда, как в примере лишь один. Чтобы избежать исключения, переменная options может быть объявлена как nil.