### PR TITLE
Add sizes field to PhotoAttachment struct

### DIFF
--- a/group.go
+++ b/group.go
@@ -92,9 +92,9 @@ func (client *VKClient) GroupGet(userID int, count int) (int, []*Group, error) {
 	return res.Count, res.Groups, nil
 }
 
-func (client *VKClient) GroupsGetByID(groipID []int) ([]*Group, error) {
+func (client *VKClient) GroupsGetByID(groupsID []int) ([]*Group, error) {
 	params := url.Values{}
-	params.Set("group_ids", ArrayToStr(groipID))
+	params.Set("group_ids", ArrayToStr(groupsID))
 	resp, err := client.MakeRequest("groups.getById", params)
 	if err != nil {
 		return nil, err

--- a/group.go
+++ b/group.go
@@ -92,6 +92,20 @@ func (client *VKClient) GroupGet(userID int, count int) (int, []*Group, error) {
 	return res.Count, res.Groups, nil
 }
 
+func (client *VKClient) GroupsGetByID(groipID []int) ([]*Group, error) {
+	params := url.Values{}
+	params.Set("group_ids", ArrayToStr(groipID))
+	resp, err := client.MakeRequest("groups.getById", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var groupsList []*Group
+	json.Unmarshal(resp.Response, &groupsList)
+
+	return groupsList, nil
+}
+
 func (client *VKClient) GroupGetMembers(group_id int, count int) (int, []*User, error) {
 	params := url.Values{}
 	params.Set("group_id", strconv.Itoa(group_id))

--- a/photo.go
+++ b/photo.go
@@ -8,21 +8,29 @@ import (
 	"strings"
 )
 
+type PhotoAttachmentSizes struct {
+	Type   string `json:"type"`
+	Url    string `json:"url"`
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
+}
+
 type PhotoAttachment struct {
-	ID        int    `json:"id"`
-	AID       int    `json:"album_id"`
-	OwnerID   int    `json:"owner_id"`
-	Photo75   string `json:"photo_75"`
-	Photo130  string `json:"photo_130"`
-	Photo604  string `json:"photo_604"`
-	Photo807  string `json:"photo_807"`
-	Photo1280 string `json:"photo_1280"`
-	Photo2560 string `json:"photo_2560"`
-	Width     int    `json:"width"`
-	Height    int    `json:"height"`
-	Text      string `json:"text"`
-	Created   int64  `json:"created"`
-	AccessKey string `json:"access_key"`
+	ID        int                    `json:"id"`
+	AID       int                    `json:"album_id"`
+	OwnerID   int                    `json:"owner_id"`
+	Photo75   string                 `json:"photo_75"`
+	Photo130  string                 `json:"photo_130"`
+	Photo604  string                 `json:"photo_604"`
+	Photo807  string                 `json:"photo_807"`
+	Photo1280 string                 `json:"photo_1280"`
+	Photo2560 string                 `json:"photo_2560"`
+	Width     int                    `json:"width"`
+	Height    int                    `json:"height"`
+	Text      string                 `json:"text"`
+	Created   int64                  `json:"created"`
+	AccessKey string                 `json:"access_key"`
+	Sizes     []PhotoAttachmentSizes `json:"sizes"`
 }
 
 type photoUploadServer struct {


### PR DESCRIPTION
- New VK API versions use a different format for photo attachments.
- groups.getById implementation