### PR TITLE
Fix wrong go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/leidruid/golang-vk-api
+module github.com/himidori/golang-vk-api
 
 go 1.12


### PR DESCRIPTION
Currently you cannot import this project since the go.mod was changed to another github account.

This fixes the issue.