### PR TITLE
Добавление опции RequestsPerSecond

### DIFF
--- a/client.go
+++ b/client.go
@@ -112,7 +112,7 @@ func NewVKClientWithToken(token string, options *TokenOptions, limitrate bool) (
 		}
 	}
 
-	if options.RequestsPerSecond > 0 {
+	if options.RequestsPerSecond > 0 && limitrate {
 		vkclient.rl.MaxRequestsPerSecond = options.RequestsPerSecond
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/ezavalishin/golang-vk-api
+module github.com/himidori/golang-vk-api
 
 go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/himidori/golang-vk-api
+module github.com/ezavalishin/golang-vk-api
 
 go 1.12


### PR DESCRIPTION
Для сервисного ключа ограничение на запросы составляет 20 в секунду

Добавляет опцию RequestsPerSecond в TokenOptions