### PR TITLE
Заменены адреса API и OAuth согласно уведомления от разработчиков ВК

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	tokenURL   = "https://oauth.vk.com/token"
-	apiURL     = "https://api.vk.com/method/%s"
+	tokenURL   = "https://oauth.vk.ru/token"
+	apiURL     = "https://api.vk.ru/method/%s"
 	apiVersion = "5.103"
 )
 


### PR DESCRIPTION
Согласно письма разработчиков, заменены адреса

```
ВКонтакте переходит на домен [vk.ru](https://vk.ru/) — теперь все API-интеграции и авторизации будут доступны только через него.

      Чтобы ваши сервисы работали корректно, до 30 сентября измените их домены — например:
      • [vk.ru/dev](https://vk.ru/dev) вместо [vk.com/dev](https://vk.com/dev)
      • [oauth.vk.ru](https://oauth.vk.ru/) вместо [oauth.vk.com](https://oauth.vk.com/)
      • [api.vk.ru](https://api.vk.ru/) вместо [api.vk.com](https://api.vk.com/)

      По всем вопросам заходите в Поддержку: [dev.vk.com/ru/support](https://dev.vk.com/ru/support)
```
